### PR TITLE
Further correction of English translation from #1

### DIFF
--- a/data/i18n.en.js
+++ b/data/i18n.en.js
@@ -166,7 +166,7 @@ window.I18N["en"] = {
       "敏捷提升": "Agility Boost",
       "力量提升": "Strength Boost",
       "意志提升": "Will Boost",
-      "智识提升": "Intelligence Boost",
+      "智识提升": "Intellect Boost",
       "主能力提升": "Main Attribute Boost"
     },
     "s2": {


### PR DESCRIPTION
"智识提升"游戏内英文原文为"Intellect Boost"

顺便提一下 201行的"暴击提升"好像是多出来的？我不确定有没有用，所以没删