### PR TITLE
修复背景图片样式问题

### DIFF
--- a/css/styles.layout.css
+++ b/css/styles.layout.css
@@ -27,7 +27,7 @@
           radial-gradient(1400px 900px at 50% 20%, rgba(77, 214, 201, 0.12), transparent 60%),
           linear-gradient(120deg, rgba(11, 15, 20, 0.92), rgba(16, 23, 34, 0.92) 45%, rgba(20, 28, 43, 0.92)),
           var(--bg-image);
-        background-size: auto, cover, auto;
+        background-size: auto, auto, cover;
         background-position: center, center, center;
         background-repeat: no-repeat, no-repeat, no-repeat;
         opacity: 1;

--- a/css/styles.theme.modes.css
+++ b/css/styles.theme.modes.css
@@ -22,7 +22,7 @@
     radial-gradient(700px 500px at 70% 90%, rgba(91, 120, 255, 0.12), transparent 60%),
     linear-gradient(120deg, rgba(255, 255, 255, 0.9), rgba(235, 243, 255, 0.9) 45%, rgba(226, 236, 252, 0.9)),
     var(--bg-image);
-  background-size: auto, auto, auto, cover, auto;
+  background-size: auto, auto, auto, auto, cover;
   background-position: center, center, center, center, center;
   background-repeat: no-repeat, no-repeat, no-repeat, no-repeat, no-repeat;
 }


### PR DESCRIPTION
目前网页的背景图片样式：
<img width="1871" height="861" alt="image" src="https://github.com/user-attachments/assets/0bd12687-5c91-474a-91c4-5a6aa177f5f6" />
<img width="1879" height="897" alt="image" src="https://github.com/user-attachments/assets/adee38b3-69cc-4b10-bbb6-eac3a8c23af8" />

修复后的样式：
<img width="1853" height="882" alt="image" src="https://github.com/user-attachments/assets/a145f38f-d3f8-4fd9-be22-babb717f0574" />
<img width="1867" height="888" alt="image" src="https://github.com/user-attachments/assets/9fb2b518-e147-4c56-9186-2c0abddc1432" />

## Summary by Sourcery

调整背景层级，以修正页面背景图片在深色和浅色主题中的显示效果。

Bug 修复：
- 修复深色模式布局样式中背景图片与渐变叠加层之间的层级顺序错误。
- 修复浅色模式主题样式中背景图片与渐变叠加层之间的层级顺序错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust background layering to correct page background image appearance in both dark and light themes.

Bug Fixes:
- Fix incorrect layering order between the background image and gradient overlays in dark mode layout styles.
- Fix incorrect layering order between the background image and gradient overlays in light mode theme styles.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **样式**
  * 调整了页面背景图层的堆叠顺序与对应尺寸映射（包括全局布局与浅色主题），改善层次感与视觉呈现。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->